### PR TITLE
Complete Phase 1 with Graph API tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 from src.api.auth_manager import AuthenticationManager
 from src.api.sharepoint_client import SharePointAPIClient
+from src.api.graph_client import GraphAPIClient
 from src.utils.retry_handler import RetryStrategy, RetryConfig
 from src.utils.rate_limiter import RateLimiter
 from src.utils.config_parser import AuthConfig
@@ -40,3 +41,8 @@ def retry_strategy():
 @pytest.fixture
 def api_client(auth_manager, retry_strategy):
     return SharePointAPIClient(auth_manager, retry_strategy, RateLimiter())
+
+
+@pytest.fixture
+def graph_client(auth_manager, retry_strategy):
+    return GraphAPIClient(auth_manager, retry_strategy, RateLimiter())

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -1,0 +1,63 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from src.utils.exceptions import GraphAPIError
+
+
+def test_graph_auth_success(auth_manager):
+    async def run():
+        with patch("src.api.auth_manager.GraphServiceClient") as MockClient, patch(
+            "src.api.auth_manager.ClientCertificateCredential"
+        ) as MockCred:
+            instance = MockClient.return_value
+            client = await auth_manager.get_graph_client()
+            assert client is instance
+            MockCred.assert_called_once()
+            MockClient.assert_called_once()
+
+    asyncio.run(run())
+
+
+def test_graph_get_with_retry(graph_client):
+    async def run():
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_get.side_effect = [
+                AsyncMock(status=429, headers={"Retry-After": "0"}),
+                AsyncMock(status=200, json=AsyncMock(return_value={"ok": True})),
+            ]
+            result = await graph_client.get_with_retry("https://graph.test.com/endpoint")
+            assert result["ok"] is True
+            assert mock_get.call_count == 2
+
+    asyncio.run(run())
+
+
+def test_graph_post_with_retry(graph_client):
+    async def run():
+        with patch("aiohttp.ClientSession.post") as mock_post:
+            mock_post.side_effect = [
+                AsyncMock(status=429, headers={"Retry-After": "0"}),
+                AsyncMock(status=200, json=AsyncMock(return_value={"ok": True})),
+            ]
+            result = await graph_client.post_with_retry(
+                "https://graph.test.com/endpoint", json={"data": 1}
+            )
+            assert result["ok"] is True
+            assert mock_post.call_count == 2
+
+    asyncio.run(run())
+
+
+def test_graph_batch_request(graph_client):
+    async def run():
+        with patch("aiohttp.ClientSession.post") as mock_post:
+            mock_post.return_value = AsyncMock(
+                status=200, json=AsyncMock(return_value={"responses": [1, 2]})
+            )
+            result = await graph_client.batch_request(
+                "https://graph.test.com/$batch", [{"id": "1"}, {"id": "2"}]
+            )
+            assert result["responses"] == [1, 2]
+            mock_post.assert_called_once()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add GraphAPIClient fixture for testing
- create tests for GraphAPIClient covering auth, get/post retry, and batch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edb938dd083249370e43b1129a861