### PR TITLE
Implement Phase 3 Discovery Module

### DIFF
--- a/src/api/graph_client.py
+++ b/src/api/graph_client.py
@@ -93,3 +93,10 @@ class GraphAPIClient:
 
         operation_id = f"batch:{url}"
         return await self.retry_strategy.execute_with_retry(operation_id, _do_batch)
+
+    async def get_all_sites_delta(self, delta_token: str | None = None) -> Any:
+        """Retrieve all sites using the delta query."""
+        url = "https://graph.microsoft.com/v1.0/sites/delta"
+        if delta_token:
+            url += f"?token={delta_token}"
+        return await self.get_with_retry(url)

--- a/src/core/discovery.py
+++ b/src/core/discovery.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Iterable
+
+from ..api.graph_client import GraphAPIClient
+from ..api.sharepoint_client import SharePointAPIClient
+from ..database.repository import DatabaseRepository
+from .progress_tracker import ProgressTracker
+from ..utils.checkpoint_manager import CheckpointManager
+
+
+class DiscoveryModule:
+    """Discovers SharePoint sites and their contents."""
+
+    def __init__(
+        self,
+        graph_client: GraphAPIClient,
+        sp_client: SharePointAPIClient,
+        db_repo: DatabaseRepository,
+        checkpoint_manager: CheckpointManager,
+    ) -> None:
+        self.graph_client = graph_client
+        self.sp_client = sp_client
+        self.db_repo = db_repo
+        self.checkpoints = checkpoint_manager
+        self.progress_tracker = ProgressTracker()
+
+    async def run_discovery(self, run_id: str) -> None:
+        sites_state = await self.checkpoints.restore_checkpoint(run_id, "sites_delta_token")
+        result = await self.graph_client.get_all_sites_delta(sites_state)
+        if getattr(result, "delta_token", None):
+            await self.checkpoints.save_checkpoint(run_id, "sites_delta_token", result.delta_token)
+        for site in result.items:
+            key = f"site_{getattr(site, 'id', '')}_status"
+            status = await self.checkpoints.restore_checkpoint(run_id, key)
+            if status == "completed":
+                self.progress_tracker.skip(key, "Already processed")
+                continue
+            await self.discover_site_content(run_id, site)
+            await self.checkpoints.save_checkpoint(run_id, key, "completed")
+
+    async def discover_site_content(self, run_id: str, site: Any) -> None:
+        tasks = [
+            self._discover_libraries(site),
+            self._discover_lists(site),
+            self._discover_subsites(site),
+        ]
+        await asyncio.gather(*tasks)
+
+    async def _discover_libraries(self, site: Any) -> Iterable[Any]:
+        return []
+
+    async def _discover_lists(self, site: Any) -> Iterable[Any]:
+        return []
+
+    async def _discover_subsites(self, site: Any) -> Iterable[Any]:
+        return []
+

--- a/src/core/progress_tracker.py
+++ b/src/core/progress_tracker.py
@@ -1,0 +1,19 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressTracker:
+    """Provides simple progress logging."""
+
+    def start(self, task_name: str) -> None:
+        logger.info("[PROGRESS] Starting: %s", task_name)
+
+    def finish(self, task_name: str, message: str = "Done") -> None:
+        logger.info("[PROGRESS] Finished: %s - %s", task_name, message)
+
+    def skip(self, task_name: str, reason: str) -> None:
+        logger.info("[PROGRESS] Skipping: %s - %s", task_name, reason)
+
+    def update(self, task_name: str, current: int, total: int) -> None:
+        logger.info("[PROGRESS] %s: %d/%d (%.1f%%)", task_name, current, total, (current / total * 100) if total else 0)

--- a/src/utils/checkpoint_manager.py
+++ b/src/utils/checkpoint_manager.py
@@ -1,0 +1,36 @@
+import json
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from ..database.repository import DatabaseRepository
+
+
+class CheckpointManager:
+    """Manages checkpoints for resumable operations."""
+
+    def __init__(self, db: DatabaseRepository) -> None:
+        self.db = db
+        self._cache: dict[str, Any] = {}
+
+    async def save_checkpoint(
+        self, run_id: str, checkpoint_type: str, state: Any
+    ) -> None:
+        await self.db.save_checkpoint(run_id, checkpoint_type, state)
+        self._cache[f"{run_id}:{checkpoint_type}"] = state
+
+    async def restore_checkpoint(
+        self, run_id: str, checkpoint_type: str
+    ) -> Optional[Any]:
+        key = f"{run_id}:{checkpoint_type}"
+        if key in self._cache:
+            return self._cache[key]
+        checkpoint = await self.db.get_latest_checkpoint(run_id, checkpoint_type)
+        if checkpoint is not None:
+            state = json.loads(checkpoint["checkpoint_data"])
+            self._cache[key] = state
+            return state
+        return None
+
+    async def cleanup_old_checkpoints(self, days: int = 7) -> None:
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        await self.db.delete_checkpoints_before(cutoff)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,99 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.core.discovery import DiscoveryModule
+from src.utils.checkpoint_manager import CheckpointManager
+from src.core.progress_tracker import ProgressTracker
+
+
+@pytest.fixture
+def mock_graph_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_sharepoint_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_checkpoint_manager():
+    manager = AsyncMock(spec=CheckpointManager)
+    return manager
+
+
+@pytest.fixture
+def discovery_module(mock_graph_client, mock_sharepoint_client, mock_checkpoint_manager, tmp_path):
+    from src.database.repository import DatabaseRepository
+
+    db_repo = DatabaseRepository(str(tmp_path / "audit.db"))
+    asyncio.run(db_repo.initialize_database())
+    module = DiscoveryModule(
+        mock_graph_client,
+        mock_sharepoint_client,
+        db_repo,
+        mock_checkpoint_manager,
+    )
+    # Speed up by disabling progress logging
+    module.progress_tracker = ProgressTracker()
+    return module
+
+
+def test_discover_all_sites_uses_delta(discovery_module, mock_graph_client, mock_checkpoint_manager):
+    async def run():
+        result = SimpleNamespace(items=[], delta_token="TEST_TOKEN")
+        mock_graph_client.get_all_sites_delta.return_value = result
+        discovery_module.discover_site_content = AsyncMock()
+
+        await discovery_module.run_discovery("test_run")
+
+        mock_checkpoint_manager.save_checkpoint.assert_any_call("test_run", "sites_delta_token", "TEST_TOKEN")
+
+    asyncio.run(run())
+
+
+def test_discover_site_content_in_parallel(discovery_module):
+    async def run():
+        test_site = SimpleNamespace(id="1")
+        async def fake_gather(*args, **kwargs):
+            fake_gather.recorded = args
+            results = []
+            for coro in args:
+                results.append(await coro)
+            return results
+
+        with patch("asyncio.gather", side_effect=fake_gather) as mock_gather:
+            discovery_module._discover_libraries = AsyncMock(return_value=[])
+            discovery_module._discover_lists = AsyncMock(return_value=[])
+            discovery_module._discover_subsites = AsyncMock(return_value=[])
+            await discovery_module.discover_site_content("run", test_site)
+            assert mock_gather.call_count == 1
+            assert len(fake_gather.recorded) > 1
+
+    asyncio.run(run())
+
+
+def test_discovery_resumes_from_checkpoint(discovery_module, mock_graph_client, mock_checkpoint_manager):
+    async def run():
+        async def restore_side_effect(run_id, key):
+            if key == "site_site1_status":
+                return "completed"
+            return None
+
+        mock_checkpoint_manager.restore_checkpoint.side_effect = restore_side_effect
+
+        site1 = SimpleNamespace(id="site1")
+        site2 = SimpleNamespace(id="site2")
+        mock_graph_client.get_all_sites_delta.return_value = SimpleNamespace(items=[site1, site2], delta_token=None)
+
+        discovery_module.discover_site_content = AsyncMock()
+
+        await discovery_module.run_discovery("test_run")
+
+        discovery_module.discover_site_content.assert_called_once_with("test_run", site2)
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- add checkpoint manager for saving/resuming state
- implement progress tracker
- add discovery module skeleton with delta token support
- extend graph client and repository for checkpoints
- test discovery behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee58d09988324b8ccacc8472b500d