### PR TITLE
Fix dataclass defaults and enable async testing

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -28,7 +28,7 @@ class AuditItem:
 @dataclass
 class Site(AuditItem):
     """Represents a SharePoint site."""
-    url: str
+    url: str = ""
     title: Optional[str] = None
     description: Optional[str] = None
     storage_used: Optional[int] = None
@@ -65,7 +65,7 @@ class Site(AuditItem):
 @dataclass
 class Library(AuditItem):
     """Represents a document library."""
-    site_id: str
+    site_id: str = ""
     description: Optional[str] = None
     item_count: int = 0
     is_hidden: bool = False
@@ -79,7 +79,7 @@ class Library(AuditItem):
 @dataclass
 class Folder(AuditItem):
     """Represents a folder."""
-    library_id: str
+    library_id: str = ""
     parent_folder_id: Optional[str] = None
     server_relative_url: str = ""
     item_count: int = 0
@@ -94,7 +94,7 @@ class Folder(AuditItem):
 @dataclass
 class File(AuditItem):
     """Represents a file."""
-    library_id: str
+    library_id: str = ""
     folder_id: Optional[str] = None
     server_relative_url: str = ""
     size_bytes: int = 0

--- a/src/core/processors.py
+++ b/src/core/processors.py
@@ -407,7 +407,11 @@ class EnrichmentStage(PipelineStage):
         # Split path and remove empty parts
         parts = [p for p in path.split("/") if p]
 
-        # Return the number of parts
+        # If the last part looks like a file name (has a dot), exclude it
+        if parts and "." in parts[-1]:
+            parts = parts[:-1]
+
+        # Return the number of directory segments
         return len(parts)
 
     def _categorize_age(self, days: int) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,42 @@ from src.utils.rate_limiter import RateLimiter
 from src.utils.config_parser import AuthConfig
 
 
+# ---------------------------------------------------------------------------
+# Minimal asyncio support for environments without pytest-asyncio
+# ---------------------------------------------------------------------------
+import asyncio
+import inspect
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "asyncio: mark test to run with asyncio event loop"
+    )
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    marker = pyfuncitem.get_closest_marker("asyncio")
+    if marker is not None and inspect.iscoroutinefunction(pyfuncitem.obj):
+        loop = pyfuncitem.funcargs.get("event_loop")
+        if loop is None:
+            loop = asyncio.new_event_loop()
+            pyfuncitem.funcargs["event_loop"] = loop
+        # Only pass arguments expected by the test function
+        funcargs = {
+            name: pyfuncitem.funcargs[name]
+            for name in pyfuncitem._fixtureinfo.argnames
+        }
+        loop.run_until_complete(pyfuncitem.obj(**funcargs))
+        return True
+
+
 @pytest.fixture
 def auth_manager():
     config = AuthConfig(


### PR DESCRIPTION
## Summary
- fix dataclass field ordering issues by providing defaults
- handle files when calculating path depth
- add minimal pytest plugin in tests to run asyncio tests without extra deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f02903bc08324b9aa30b646434586