### PR TITLE
Implement Phase 8 dashboard skeleton

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -328,11 +328,8 @@ def dashboard(ctx, db_path, port, no_browser):
     # Check if streamlit app exists
     streamlit_app_path = Path(__file__).parent.parent / "dashboard" / "streamlit_app.py"
     if not streamlit_app_path.exists():
-        output.warning("Dashboard not yet implemented (Phase 8)")
-        output.info("Creating placeholder dashboard...")
-        # Create a minimal placeholder
-        streamlit_app_path.parent.mkdir(parents=True, exist_ok=True)
-        streamlit_app_path.write_text(_get_placeholder_dashboard())
+        output.error(f"Dashboard app not found: {streamlit_app_path}")
+        ctx.exit(1)
 
     # Build streamlit command
     command = [
@@ -530,54 +527,3 @@ def health(ctx, config, check_auth, check_api, check_db):
         ctx.exit(1)
 
 
-def _get_placeholder_dashboard():
-    """Get placeholder dashboard code."""
-    return '''"""Placeholder dashboard for SharePoint Audit (Phase 8 - To be implemented)."""
-
-import streamlit as st
-import sys
-from pathlib import Path
-
-st.set_page_config(
-    page_title="SharePoint Audit Dashboard",
-    page_icon="📊",
-    layout="wide"
-)
-
-st.title("SharePoint Audit Dashboard")
-st.info("This dashboard will be implemented in Phase 8 of the development plan.")
-
-# Parse command line arguments
-db_path = None
-if "--db-path" in sys.argv:
-    idx = sys.argv.index("--db-path")
-    if idx + 1 < len(sys.argv):
-        db_path = sys.argv[idx + 1]
-
-if db_path and Path(db_path).exists():
-    st.success(f"Database found: {db_path}")
-
-    st.subheader("Planned Features")
-    col1, col2 = st.columns(2)
-
-    with col1:
-        st.markdown("""
-        **Analytics & Visualizations**
-        - Site storage usage charts
-        - File type distribution
-        - Permission complexity metrics
-        - User access patterns
-        """)
-
-    with col2:
-        st.markdown("""
-        **Data Exploration**
-        - Browse sites and libraries
-        - Search files and folders
-        - View permission reports
-        - Export audit data
-        """)
-else:
-    st.error("No database path provided or database not found.")
-    st.info("Usage: streamlit run streamlit_app.py -- --db-path /path/to/audit.db")
-'''

--- a/src/dashboard/components/export.py
+++ b/src/dashboard/components/export.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+def create_download_button(data: bytes, filename: str) -> None:
+    """Provide a simple download button."""
+    st.download_button(
+        label="Download",
+        data=data,
+        file_name=filename,
+        mime="application/octet-stream",
+    )

--- a/src/dashboard/pages/__init__.py
+++ b/src/dashboard/pages/__init__.py
@@ -1,0 +1,3 @@
+from . import overview, permissions, files, export
+
+__all__ = ['overview', 'permissions', 'files', 'export']

--- a/src/dashboard/pages/export.py
+++ b/src/dashboard/pages/export.py
@@ -1,0 +1,9 @@
+import streamlit as st
+from ..components import export as export_component
+
+
+def render(db_path: str) -> None:
+    """Render export page."""
+    st.title("Export Data")
+    if st.button("Generate Export"):
+        export_component.create_download_button(b"data", "audit_data.txt")

--- a/src/dashboard/pages/files.py
+++ b/src/dashboard/pages/files.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+
+def render(db_path: str) -> None:
+    """Render files analysis page."""
+    st.title("File Analysis")
+    st.write("Coming soon")

--- a/src/dashboard/pages/overview.py
+++ b/src/dashboard/pages/overview.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+
+def render(db_path: str) -> None:
+    """Render the dashboard overview page."""
+    st.title("SharePoint Audit Dashboard")
+    st.write(f"Database: {db_path}")

--- a/src/dashboard/pages/permissions.py
+++ b/src/dashboard/pages/permissions.py
@@ -1,0 +1,23 @@
+import streamlit as st
+
+
+def _sample_data(site: str) -> list[dict]:
+    return [
+        {"object_name": "FileA.docx", "principal_name": "User1", "permission_level": "Edit", "site": site},
+        {"object_name": "FolderB", "principal_name": "GroupA", "permission_level": "Read", "site": site},
+    ]
+
+
+@st.cache_data(ttl=300)
+def load_permission_data(db_path: str, site_filter: str) -> list[dict]:
+    # In the real app this would query the database
+    return _sample_data(site_filter)
+
+
+def render(db_path: str) -> None:
+    """Render permissions analysis page."""
+    st.title("Permission Analysis")
+    site_filter = st.selectbox("Filter by Site", ["Site A", "Site B"], key="site_filter")
+    data = load_permission_data(db_path, site_filter)
+    st.dataframe(data)
+    st.bar_chart([1, 2])

--- a/src/dashboard/streamlit_app.py
+++ b/src/dashboard/streamlit_app.py
@@ -1,0 +1,28 @@
+import argparse
+import streamlit as st
+from .pages import overview, permissions, files, export
+
+def main(args=None):
+    parser = argparse.ArgumentParser(description="SharePoint Audit Dashboard")
+    parser.add_argument('--db-path', default='audit.db', help='Path to audit database')
+    parsed = parser.parse_args(args)
+
+    st.set_page_config(
+        page_title="SharePoint Audit Dashboard",
+        layout="wide",
+        initial_sidebar_state="expanded"
+    )
+
+    st.sidebar.title("Navigation")
+    page_options = {
+        "Overview": overview.render,
+        "Permissions": permissions.render,
+        "Files": files.render,
+        "Export": export.render,
+    }
+    selection = st.sidebar.radio("Go to", list(page_options.keys()))
+    page_func = page_options[selection]
+    page_func(parsed.db_path)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _create_stub_streamlit(selected_page="Overview", site_selection="Site A"):
+    """Create a minimal streamlit stub for testing."""
+    stub = ModuleType("streamlit")
+    sidebar = SimpleNamespace(
+        title=lambda *a, **k: None,
+        radio=lambda label, options: selected_page,
+        button=lambda *a, **k: False,
+    )
+    stub.sidebar = sidebar
+    stub.set_page_config = lambda *a, **k: None
+    stub.title = lambda *a, **k: None
+    stub.write = lambda *a, **k: None
+    stub.dataframe = lambda *a, **k: None
+    stub.bar_chart = lambda *a, **k: None
+    stub.selectbox = lambda label, options, **k: site_selection
+    stub.download_button = lambda *a, **k: None
+    stub.button = lambda *a, **k: False
+
+    def cache_data(ttl=None):
+        def decorator(func):
+            return func
+        return decorator
+
+    stub.cache_data = cache_data
+    return stub
+
+
+def test_dashboard_main_loads(monkeypatch):
+    st_stub = _create_stub_streamlit()
+    monkeypatch.setitem(sys.modules, 'streamlit', st_stub)
+    import src.dashboard.streamlit_app as app
+    importlib.reload(app)
+    app.main(['--db-path', 'test.db'])
+    # The overview page sets the title
+    assert True  # If no exception, test passes
+
+
+def test_permissions_page_filtering(monkeypatch):
+    st_stub = _create_stub_streamlit(selected_page="Permissions", site_selection="Site B")
+    monkeypatch.setitem(sys.modules, 'streamlit', st_stub)
+    import src.dashboard.pages.permissions as perm
+    importlib.reload(perm)
+    monkeypatch.setattr(perm, 'load_permission_data', lambda db, site: [{"site": site}])
+    import src.dashboard.streamlit_app as app
+    importlib.reload(app)
+    app.main(['--db-path', 'test.db'])
+    assert True  # Ran without errors


### PR DESCRIPTION
## Summary
- implement a minimal Streamlit dashboard with pages and export component
- update CLI dashboard command to require real dashboard app
- add basic dashboard tests using a stubbed Streamlit module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f3d465f4832491b521ac4231c651