### PR TITLE
Fix CLI site filtering and duplicate site insertions

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,68 +6,103 @@ from unittest.mock import patch
 
 def _ensure_rich_modules():
     """Create minimal rich stubs if rich is not installed."""
-    if 'rich' in sys.modules:
+    if "rich" in sys.modules:
         return
-    rich = ModuleType('rich')
-    console_mod = ModuleType('rich.console')
+    rich = ModuleType("rich")
+    console_mod = ModuleType("rich.console")
+
     class DummyConsole:
         def print(self, *args, **kwargs):
             pass
+
         class _Status:
             def __init__(self, msg):
                 self.msg = msg
+
             def __enter__(self):
                 return self
+
             def __exit__(self, exc_type, exc, tb):
                 pass
+
         def status(self, message, *a, **k):
             return DummyConsole._Status(message)
+
     console_mod.Console = DummyConsole
-    progress_mod = ModuleType('rich.progress')
+    progress_mod = ModuleType("rich.progress")
+
     class DummyProgress:
         def __init__(self, *a, **k):
             pass
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
+
         def add_task(self, *a, **k):
             return 0
+
         def update(self, *a, **k):
             pass
+
         def stop(self):
             pass
+
     progress_mod.Progress = DummyProgress
-    progress_mod.SpinnerColumn = progress_mod.TextColumn = progress_mod.BarColumn = progress_mod.TaskProgressColumn = progress_mod.TimeRemainingColumn = object
-    table_mod = ModuleType('rich.table')
+    progress_mod.SpinnerColumn = progress_mod.TextColumn = progress_mod.BarColumn = (
+        progress_mod.TaskProgressColumn
+    ) = progress_mod.TimeRemainingColumn = object
+    table_mod = ModuleType("rich.table")
+
     class DummyTable:
         def __init__(self, *a, **k):
             pass
+
         def add_column(self, *a, **k):
             pass
+
         def add_row(self, *a, **k):
             pass
+
     table_mod.Table = DummyTable
-    logging_mod = ModuleType('rich.logging')
+    logging_mod = ModuleType("rich.logging")
+
     class DummyHandler:
         def __init__(self, *a, **k):
             pass
+
         def emit(self, *a, **k):
             pass
+
     logging_mod.RichHandler = DummyHandler
-    panel_mod = ModuleType('rich.panel')
+    panel_mod = ModuleType("rich.panel")
+
     class DummyPanel:
         def __init__(self, *a, **k):
             pass
+
     panel_mod.Panel = DummyPanel
-    text_mod = ModuleType('rich.text')
+    text_mod = ModuleType("rich.text")
+
     class DummyText:
         def __init__(self, *a, **k):
             pass
+
         def append(self, *a, **k):
             pass
+
     text_mod.Text = DummyText
-    for mod in [rich, console_mod, progress_mod, table_mod, logging_mod, panel_mod, text_mod]:
+    for mod in [
+        rich,
+        console_mod,
+        progress_mod,
+        table_mod,
+        logging_mod,
+        panel_mod,
+        text_mod,
+    ]:
         sys.modules[mod.__name__] = mod
 
 
@@ -78,20 +113,68 @@ def test_audit_command_with_config(tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem():
         config_path = tmp_path / "config.json"
-        config_path.write_text('{"auth": {"tenant_id": "tid", "client_id": "cid", "certificate_path": "cert.pem"}}')
+        config_path.write_text(
+            '{"auth": {"tenant_id": "tid", "client_id": "cid", "certificate_path": "cert.pem"}}'
+        )
         dummy_config = {
-            'auth': {
-                'tenant_id': 'tid',
-                'client_id': 'cid',
-                'certificate_path': 'cert.pem'
+            "auth": {
+                "tenant_id": "tid",
+                "client_id": "cid",
+                "certificate_path": "cert.pem",
             },
-            'db': {'path': 'audit.db'}
+            "db": {"path": "audit.db"},
         }
-        with patch('src.cli.commands.setup_logging'), \
-             patch('src.cli.commands.load_and_merge_config', return_value=dummy_config), \
-             patch('src.cli.commands._run_audit', return_value=None):
-            result = runner.invoke(cli, ['audit', '--config', str(config_path)])
+        with patch("src.cli.commands.setup_logging"), patch(
+            "src.cli.commands.load_and_merge_config", return_value=dummy_config
+        ), patch("src.cli.commands._run_audit", return_value=None):
+            result = runner.invoke(cli, ["audit", "--config", str(config_path)])
             assert result.exit_code == 0
+
+
+def test_audit_command_passes_sites(tmp_path):
+    _ensure_rich_modules()
+    from src.cli.main import cli
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            '{"auth": {"tenant_id": "tid", "client_id": "cid", "certificate_path": "cert.pem"}}'
+        )
+        dummy_config = {
+            "auth": {
+                "tenant_id": "tid",
+                "client_id": "cid",
+                "certificate_path": "cert.pem",
+            },
+            "db": {"path": "audit.db"},
+            "target_sites": ["https://contoso.sharepoint.com/sites/test"],
+        }
+
+        def fake_load(path, cli_args=None):
+            # Ensure CLI args include the target site
+            assert cli_args["target_sites"] == [
+                "https://contoso.sharepoint.com/sites/test"
+            ]
+            return dummy_config
+
+        with patch("src.cli.commands.setup_logging"), patch(
+            "src.cli.commands.load_and_merge_config", side_effect=fake_load
+        ) as load_mock, patch(
+            "src.cli.commands._run_audit", return_value=None
+        ) as run_mock:
+            result = runner.invoke(
+                cli,
+                [
+                    "audit",
+                    "--config",
+                    str(config_path),
+                    "--sites",
+                    "https://contoso.sharepoint.com/sites/test",
+                ],
+            )
+            assert result.exit_code == 0
+            run_mock.assert_called_once()
 
 
 def test_dashboard_command():
@@ -99,10 +182,11 @@ def test_dashboard_command():
     from src.cli.main import cli
 
     runner = CliRunner()
-    with patch('subprocess.run') as mock_run, \
-         patch('pathlib.Path.exists', return_value=True):
-        result = runner.invoke(cli, ['dashboard', '--db-path', 'test.db'])
+    with patch("subprocess.run") as mock_run, patch(
+        "pathlib.Path.exists", return_value=True
+    ):
+        result = runner.invoke(cli, ["dashboard", "--db-path", "test.db"])
         assert result.exit_code == 0
-        assert 'streamlit' in mock_run.call_args[0][0]
-        assert '--db-path' in mock_run.call_args[0][0]
-        assert 'test.db' in mock_run.call_args[0][0]
+        assert "streamlit" in mock_run.call_args[0][0]
+        assert "--db-path" in mock_run.call_args[0][0]
+        assert "test.db" in mock_run.call_args[0][0]


### PR DESCRIPTION
## Summary
- use upsert when saving sites to avoid duplicate failures
- pass `target_sites` from config to pipeline context
- test that CLI forwards `--sites` option

## Testing
- `black src/cli/commands.py src/core/discovery.py tests/test_cli.py`
- `flake8 src/cli/commands.py src/core/discovery.py tests/test_cli.py` *(failed: command not found)*
- `mypy src/cli/commands.py src/core/discovery.py tests/test_cli.py` *(errors: missing stubs)*
- `pre-commit run --files src/cli/commands.py src/core/discovery.py tests/test_cli.py` *(failed: command not found)*
- `pytest -q` *(failed: 4 failed, 24 passed)*


------
https://chatgpt.com/codex/tasks/task_e_6865741def248324bb75733bf83e2c7a

## Summary by Sourcery

Fix duplicate site insertion errors by switching to upsert, enable audit filtering via the --sites option and propagate it through to the pipeline, and add tests to cover the new filtering behavior.

New Features:
- Allow specifying specific site URLs to audit via the --sites CLI option

Bug Fixes:
- Prevent duplicate site insertions by using bulk upsert when saving sites to the database

Enhancements:
- Propagate target_sites from CLI and merged config into the audit pipeline context

Tests:
- Add a test to verify the CLI’s --sites option is correctly forwarded and handled